### PR TITLE
Feature: add report upload with file storage and public URL return in Laravel

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+use App\Http\Controllers\Controller;
+use App\Repositories\StorageRepository;
+
+class ReportController extends Controller
+{
+    public function __construct(
+        private StorageRepository $storageRepo
+    ) {}
+
+    public function uploadReport(Request $request,$patient_id)
+    {
+        if (!$request->hasFile('medical-report')) {
+            return response()->json(['error' => 'No report file uploaded.'], 422);
+        }
+
+        $report = $request->file('medical-report');
+
+        $url = $this->storageRepo->store_report($report,$patient_id);
+
+        return response()->json([
+            'url' => $url,
+        ],201);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -24,5 +24,9 @@ class AppServiceProvider extends ServiceProvider
         Route::middleware('api')
             ->prefix('auth')
             ->group(base_path('routes/auth.php'));
+
+        Route::middleware('api')
+            ->prefix('report')
+            ->group(base_path('routes/report.php'));
     }
 }

--- a/app/Repositories/StorageRepository.php
+++ b/app/Repositories/StorageRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Repositories;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class StorageRepository
+{
+    public function disk()
+    {
+        return Storage::disk('report_storage');
+    }
+    public function store_report(UploadedFile $report,string $patient_id): string
+    {
+        $filename = 'medical-report' ."-{$patient_id}-". Str::random(8) . '.' . $report->getClientOriginalExtension();
+
+        $relativePath = $report->storeAs(
+            '',
+            $filename,
+            'report_storage'
+        );
+
+        return $this->disk()->url($relativePath);
+    }
+}

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -41,10 +41,18 @@ return [
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),
-            'url' => env('APP_URL').'/storage',
+            'url' => env('APP_URL') . '/storage',
             'visibility' => 'public',
             'throw' => false,
             'report' => false,
+        ],
+
+        'report_storage' => [
+            'driver' => 'local',
+            'root' => storage_path('app/public/reports'),
+            'url' => env('APP_URL') . '/storage/reports',
+            'visibility' => 'public',
+            'throw' => true
         ],
 
         's3' => [

--- a/routes/report.php
+++ b/routes/report.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\ReportController;
+
+
+Route::post('/upload/{patient_id}', [ReportController::class, 'uploadReport']);


### PR DESCRIPTION

# PR: Add Report Upload with File Storage and Public URL Return

## Context
This PR introduces the ability to upload report files through a dedicated endpoint in the MediVault backend. Uploaded files are stored securely using Laravel’s filesystem configuration, and a public URL is returned. This is the foundation for report digitalization and storage workflows in the system.

## Description
This update includes:

- Storage configuration for reports
- A custom route file for report-related endpoints
- A controller for handling the upload logic
- A repository layer that handles uploads and returns public file links
## Changes in the Codebase

### Core Structure
```
app/  
├── Http/  
│ └── Controllers/ReportController.php # Handles report upload  
├── Providers/AppServiceProvider.php # Registers report route file  
├── Repositories/StorageRepository.php # Manages upload and URL return  
config/  
└── filesystems.php # Adds report-specific disk config  
routes/  
└── report.php # Defines upload endpoint
```
### Logical Flow

- `/report/upload/{patient_id}` receives the file through a POST request  
- The controller passes the file to the storage helper (`StorageRepository`)  
- The file is saved, and a public link is sent back in the response

## Changes Outside the Codebase

- No external APIs or services used
- No DB schema changes
- No CI/CD or infrastructure updates

## Additional Information

- Files are stored using Laravel's `storage/app/public` disk
- Public access is enabled via symbolic linking (`php artisan storage:link`)
- Future additions may include access control, expiry, and metadata handling
